### PR TITLE
Harden API calls and environment validation in monitoring scripts

### DIFF
--- a/jira_done_checker.py
+++ b/jira_done_checker.py
@@ -1,23 +1,55 @@
-import requests, time, urllib3, re, logging, sys, os
+import base64
+import logging
+import os
+import re
+import sys
+import time
 from datetime import datetime, timedelta
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', 
-                   handlers=[logging.FileHandler('jira_done_checker.log'), logging.StreamHandler()])
+import requests
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[logging.FileHandler('jira_done_checker.log'), logging.StreamHandler()],
+)
 logger = logging.getLogger(__name__)
 
 GITLAB_TOKEN = os.getenv("GITLAB_TOKEN")
 JIRA_TOKEN = os.getenv("JIRA_TOKEN")
 PACCHA_BOT_TOKEN = os.getenv("PACCHA_BOT_TOKEN")
-PACHA_CHAT_ID = int(os.getenv("PACHA_CHAT_ID"))
+PACHA_CHAT_ID = os.getenv("PACHA_CHAT_ID")
 JIRA_URL = "https://jira.lamoda.ru"
+CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", "30"))
+REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
 
-def send_pacha_message(text):
+
+def validate_env() -> int:
+    required = {
+        "GITLAB_TOKEN": GITLAB_TOKEN,
+        "JIRA_TOKEN": JIRA_TOKEN,
+        "PACCHA_BOT_TOKEN": PACCHA_BOT_TOKEN,
+        "PACHA_CHAT_ID": PACHA_CHAT_ID,
+    }
+    missing = [key for key, value in required.items() if not value]
+    if missing:
+        raise RuntimeError(f"Не заданы обязательные переменные окружения: {', '.join(missing)}")
+
     try:
-        logger.info(f"Отправка сообщения в Pachca: {text}")
-        resp = requests.post("https://api.pachca.com/api/shared/v1/messages", 
-                           json={"message": {"entity_id": PACHA_CHAT_ID, "content": text}}, 
-                           headers={"Authorization": f"Bearer {PACCHA_BOT_TOKEN}", "Content-Type": "application/json"})
+        return int(PACHA_CHAT_ID)
+    except ValueError as exc:
+        raise RuntimeError("PACHA_CHAT_ID должен быть целым числом") from exc
+
+
+def send_pacha_message(text, chat_id: int):
+    try:
+        logger.info("Отправка сообщения в Pachca")
+        resp = requests.post(
+            "https://api.pachca.com/api/shared/v1/messages",
+            json={"message": {"entity_id": chat_id, "content": text}},
+            headers={"Authorization": f"Bearer {PACCHA_BOT_TOKEN}", "Content-Type": "application/json"},
+            timeout=REQUEST_TIMEOUT,
+        )
         resp.raise_for_status()
         logger.info("Сообщение в Pachca успешно отправлено")
         return resp.json()
@@ -25,73 +57,70 @@ def send_pacha_message(text):
         logger.error(f"Ошибка при отправке сообщения в Pachca: {e}")
         raise
 
-def get_merged_mrs():
+
+def get_merged_mrs(chat_id: int):
     try:
         logger.info("Получение списка замерженных MR")
-        r = requests.get(f"https://gitlab.lamoda.tech/api/v4/merge_requests?state=merged&author_username=aleksey.kuryshev", 
-                       headers={"PRIVATE-TOKEN": GITLAB_TOKEN}, verify=False)
+        r = requests.get(
+            "https://gitlab.lamoda.tech/api/v4/merge_requests?state=merged&author_username=aleksey.kuryshev",
+            headers={"PRIVATE-TOKEN": GITLAB_TOKEN},
+            timeout=REQUEST_TIMEOUT,
+        )
         r.raise_for_status()
         project_mrs = r.json()
         logger.info(f"Найдено {len(project_mrs)} замерженных MR")
-        
-        # Сохраняем project_id для каждого MR
+
         for mr in project_mrs:
             mr['_project_id'] = mr.get('project_id', 123)
         return project_mrs
     except requests.exceptions.ConnectionError as e:
         if "NameResolutionError" in str(e) or "Failed to resolve" in str(e):
-            logger.error(f"Не удалось разрешить имя хоста gitlab.lamoda.tech. Завершение программы.")
+            logger.error("Не удалось разрешить имя хоста gitlab.lamoda.tech. Завершение программы.")
             logger.error(f"Детали ошибки: {e}")
             try:
-                send_pacha_message("❌ Не удалось подключиться к GitLab: ошибка разрешения DNS. Программа завершена.")
-            except:
+                send_pacha_message("❌ Не удалось подключиться к GitLab: ошибка разрешения DNS. Программа завершена.", chat_id)
+            except Exception:
                 pass
             sys.exit(1)
-        else:
-            logger.error(f"Ошибка подключения к GitLab: {e}")
-            raise
+        logger.error(f"Ошибка подключения к GitLab: {e}")
+        raise
     except Exception as e:
         logger.error(f"Ошибка при получении списка замерженных MR: {e}")
         raise
+
 
 def extract_jira_key_from_text(text):
     try:
         match = re.search(r'\b[A-Z]+-\d+\b', text)
         jira_key = match.group(0) if match else None
-        logger.info(f"Найден ключ Jira: {jira_key} в тексте: {text[:100]}...")
+        logger.info(f"Найден ключ Jira: {jira_key}")
         return jira_key
     except Exception as e:
         logger.error(f"Ошибка при поиске ключа Jira в тексте: {e}")
         return None
 
+
 def get_jira_issue_status(jira_key):
     try:
         logger.info(f"Проверка статуса задачи {jira_key} в Jira")
         url = f"{JIRA_URL}/rest/api/2/issue/{jira_key}?fields=status"
-        
-        # Пробуем сначала Bearer token
+
         headers = {
             "Accept": "application/json",
-            "Authorization": f"Bearer {JIRA_TOKEN}"
+            "Authorization": f"Bearer {JIRA_TOKEN}",
         }
-        
-        r = requests.get(url, headers=headers, verify=False)
-        
-        # Если Bearer не сработал, пробуем Basic auth
-        if r.status_code == 401:
+        r = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+
+        if r.status_code == 401 and ":" in JIRA_TOKEN:
             logger.info("Bearer token не сработал, пробую Basic auth")
-            import base64
-            # Для Basic auth нужно использовать email:api_token
-            # Предполагаем что JIRA_TOKEN это email:api_token
-            if ":" in JIRA_TOKEN:
-                auth_headers = {
-                    "Accept": "application/json",
-                    "Authorization": f"Basic {base64.b64encode(JIRA_TOKEN.encode()).decode()}"
-                }
-                r = requests.get(url, headers=auth_headers, verify=False)
-        
+            auth_headers = {
+                "Accept": "application/json",
+                "Authorization": f"Basic {base64.b64encode(JIRA_TOKEN.encode()).decode()}",
+            }
+            r = requests.get(url, headers=auth_headers, timeout=REQUEST_TIMEOUT)
+
         r.raise_for_status()
-        
+
         issue_data = r.json()
         status = issue_data["fields"]["status"]["name"]
         logger.info(f"Задача {jira_key} имеет статус: {status}")
@@ -100,11 +129,15 @@ def get_jira_issue_status(jira_key):
         logger.error(f"Ошибка при получении статуса задачи {jira_key}: {e}")
         return None
 
+
 def get_mr_merged_time(mr_iid, project_id):
     try:
         logger.info(f"Получение времени мерджа для MR !{mr_iid}")
-        r = requests.get(f"https://gitlab.lamoda.tech/api/v4/projects/{project_id}/merge_requests/{mr_iid}", 
-                       headers={"PRIVATE-TOKEN": GITLAB_TOKEN}, verify=False)
+        r = requests.get(
+            f"https://gitlab.lamoda.tech/api/v4/projects/{project_id}/merge_requests/{mr_iid}",
+            headers={"PRIVATE-TOKEN": GITLAB_TOKEN},
+            timeout=REQUEST_TIMEOUT,
+        )
         r.raise_for_status()
         time.sleep(1)
         mr_data = r.json()
@@ -113,12 +146,12 @@ def get_mr_merged_time(mr_iid, project_id):
         logger.error(f"Ошибка при получении времени мерджа для MR !{mr_iid}: {e}")
         return None
 
+
 def should_send_reminder(merged_at):
     try:
         if not merged_at:
             return False
-            
-        # Парсим время мерджа
+
         try:
             merged_time = datetime.strptime(merged_at, "%Y-%m-%dT%H:%M:%S.%fZ")
         except ValueError:
@@ -128,56 +161,51 @@ def should_send_reminder(merged_at):
             except ValueError:
                 logger.error(f"Неизвестный формат времени мерджа: {merged_at}")
                 return False
-        
+
         now = datetime.now()
         time_diff = now - merged_time
-        
-        # Проверяем что прошло больше 1 часа
         return time_diff > timedelta(hours=1)
     except Exception as e:
         logger.error(f"Ошибка при проверке времени для напоминания: {e}")
         return False
 
+
 def main():
+    chat_id = validate_env()
     logger.info("Запуск проверки задач в статусе Done...")
-    send_pacha_message("Запуск проверки задач в статусе Done...")
-    # Глобальный словарь для хранения отправленных уведомлений
+    send_pacha_message("Запуск проверки задач в статусе Done...", chat_id)
     sent_reminders = {}
+
     while True:
         try:
-            merged_mrs = get_merged_mrs()
+            merged_mrs = get_merged_mrs(chat_id)
             reminders_sent = []
-            
+
             for mr in merged_mrs:
                 iid = mr["iid"]
                 title = mr["title"]
                 project_id = mr['_project_id']
                 merged_at = mr.get("merged_at")
-                
+
                 logger.info(f"Проверка MR !{iid}: {title}")
-                
-                # Извлекаем ключ Jira из заголовка и описания
                 jira_key = extract_jira_key_from_text(title + " " + mr.get("description", ""))
-                
+
                 if not jira_key:
                     logger.info(f"В MR !{iid} не найден ключ Jira, пропускаем")
                     continue
-                
-                # Проверяем не отправляли ли уже напоминание для этой задачи
+
                 if jira_key in sent_reminders:
                     logger.info(f"Для задачи {jira_key} уже отправлялось напоминание, пропускаем")
                     continue
-                
-                # Проверяем статус задачи в Jira
+
                 jira_status = get_jira_issue_status(jira_key)
-                
-                if jira_status and jira_status.lower() != "done" and jira_status.lower() != "cancelled":
+
+                if jira_status and jira_status.lower() not in {"done", "cancelled"}:
                     logger.info(f"Задача {jira_key} не в статусе Done или Cancelled (текущий: {jira_status}), проверяем время")
-                    
+
                     if should_send_reminder(merged_at):
-                        # Получаем точное время мерджа
                         actual_merged_at = get_mr_merged_time(iid, project_id) or merged_at
-                        
+
                         try:
                             merged_time = datetime.strptime(actual_merged_at, "%Y-%m-%dT%H:%M:%S.%fZ")
                         except ValueError:
@@ -185,44 +213,47 @@ def main():
                                 merged_time = datetime.strptime(actual_merged_at, "%Y-%m-%dT%H:%M:%S.%f%z")
                                 merged_time = merged_time.replace(tzinfo=None)
                             except ValueError:
-                                merged_time = datetime.now() - timedelta(hours=2)  # Fallback
-                        
+                                merged_time = datetime.now() - timedelta(hours=2)
+
                         time_diff = datetime.now() - merged_time
                         hours_passed = int(time_diff.total_seconds() // 3600)
-                        
+
                         mr_link = mr.get("web_url", "")
                         jira_link = f"{JIRA_URL}/browse/{jira_key}"
-                        
+
                         message = f"⏰ Напоминание: задача {jira_key} не в статусе Done уже {hours_passed} часов после мерджа MR!\n"
                         message += f"MR был замержен: {merged_time.strftime('%Y-%m-%d %H:%M')}\n"
                         message += f"Текущий статус: {jira_status}\n"
                         message += f"Задача: {jira_link}\n"
                         if mr_link:
                             message += f"MR: {mr_link}\n"
-                        message += f"\nВозможно нужно перевести задачу в статус Done?"
-                        
+                        message += "\nВозможно нужно перевести задачу в статус Done?"
+
                         logger.info(f"Отправка напоминания для задачи {jira_key}")
-                        send_pacha_message(message)
-                        
-                        # Отмечаем что отправили напоминание
+                        send_pacha_message(message, chat_id)
+
                         sent_reminders[jira_key] = datetime.now()
                         reminders_sent.append(jira_key)
                     else:
                         logger.info(f"Для задачи {jira_key} еще рано отправлять напоминание")
                 else:
                     logger.info(f"Задача {jira_key} в статусе Done или Cancelled, пропускаем")
-            
+
             if reminders_sent:
                 logger.info(f"Отправлено {len(reminders_sent)} напоминаний: {', '.join(reminders_sent)}")
             else:
                 logger.info("Напоминания не требуются")
-                
+
         except Exception as e:
             logger.error(f"Ошибка в основной программе: {e}", exc_info=True)
             try:
-                send_pacha_message(f"❌ Ошибка в проверке задач Jira: {e}")
+                send_pacha_message(f"❌ Ошибка в проверке задач Jira: {e}", chat_id)
             except Exception as notify_error:
                 logger.error(f"Не удалось отправить уведомление об ошибке: {notify_error}")
+
+        logger.info(f"Следующая проверка через {CHECK_INTERVAL} секунд")
+        time.sleep(CHECK_INTERVAL)
+
 
 if __name__ == "__main__":
     main()

--- a/merge.py
+++ b/merge.py
@@ -1,6 +1,13 @@
-import requests, time, urllib3, re, logging, signal, sys, os, json
+import logging
+import os
+import re
+import signal
+import sys
+import time
+from typing import Optional
+
+import requests
 from datetime import datetime, timedelta
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s', 
                    handlers=[logging.FileHandler('merge_monitor.log'), logging.StreamHandler()])
@@ -10,18 +17,38 @@ GITLAB_TOKEN = os.getenv("GITLAB_TOKEN")
 TARGET_APPROVALS = 3
 CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", "30"))
 PACCHA_BOT_TOKEN = os.getenv("PACCHA_BOT_TOKEN")
-PACHA_CHAT_ID = int(os.getenv("PACHA_CHAT_ID"))
+PACHA_CHAT_ID = os.getenv("PACHA_CHAT_ID")
 JIRA_TOKEN = os.getenv("JIRA_TOKEN")
 JIRA_URL = "https://jira.lamoda.ru"
+REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
 
 # ----------------------------
 
-def send_pacha_message(text):
+def validate_env() -> int:
+    required = {
+        "GITLAB_TOKEN": GITLAB_TOKEN,
+        "PACCHA_BOT_TOKEN": PACCHA_BOT_TOKEN,
+        "PACHA_CHAT_ID": PACHA_CHAT_ID,
+    }
+    missing = [key for key, value in required.items() if not value]
+    if missing:
+        raise RuntimeError(f"Не заданы обязательные переменные окружения: {', '.join(missing)}")
+
     try:
-        logger.info(f"Отправка сообщения в Pachca: {text}")
-        resp = requests.post("https://api.pachca.com/api/shared/v1/messages", 
-                           json={"message": {"entity_id": PACHA_CHAT_ID, "content": text}}, 
-                           headers={"Authorization": f"Bearer {PACCHA_BOT_TOKEN}", "Content-Type": "application/json"})
+        return int(PACHA_CHAT_ID)
+    except ValueError as exc:
+        raise RuntimeError("PACHA_CHAT_ID должен быть целым числом") from exc
+
+
+def send_pacha_message(text: str, chat_id: int):
+    try:
+        logger.info("Отправка сообщения в Pachca")
+        resp = requests.post(
+            "https://api.pachca.com/api/shared/v1/messages",
+            json={"message": {"entity_id": chat_id, "content": text}},
+            headers={"Authorization": f"Bearer {PACCHA_BOT_TOKEN}", "Content-Type": "application/json"},
+            timeout=REQUEST_TIMEOUT,
+        )
         resp.raise_for_status()
         logger.info("Сообщение в Pachca успешно отправлено")
         return resp.json()
@@ -29,11 +56,14 @@ def send_pacha_message(text):
         logger.error(f"Ошибка при отправке сообщения в Pachca: {e}")
         raise
 
-def get_open_mrs():
+def get_open_mrs(chat_id: int):
     try:
         logger.info("Получение списка открытых MR")
-        r = requests.get(f"https://gitlab.lamoda.tech/api/v4/merge_requests?state=opened&author_username=aleksey.kuryshev", 
-                       headers={"PRIVATE-TOKEN": GITLAB_TOKEN}, verify=False)
+        r = requests.get(
+            "https://gitlab.lamoda.tech/api/v4/merge_requests?state=opened&author_username=aleksey.kuryshev",
+            headers={"PRIVATE-TOKEN": GITLAB_TOKEN},
+            timeout=REQUEST_TIMEOUT,
+        )
         r.raise_for_status()
         project_mrs = r.json()
         logger.info(f"Найдено {len(project_mrs)} MR")
@@ -46,8 +76,8 @@ def get_open_mrs():
             logger.error(f"Не удалось разрешить имя хоста gitlab.lamoda.tech. Завершение программы.")
             logger.error(f"Детали ошибки: {e}")
             try:
-                send_pacha_message("❌ Не удалось подключиться к GitLab: ошибка разрешения DNS. Программа завершена.")
-            except:
+                send_pacha_message("❌ Не удалось подключиться к GitLab: ошибка разрешения DNS. Программа завершена.", chat_id)
+            except Exception:
                 pass
             sys.exit(1)
         else:
@@ -60,8 +90,11 @@ def get_open_mrs():
 def get_approval_count(mr_iid, project_id):
     try:
         logger.info(f"Получение количества аппрувов для MR !{mr_iid}")
-        r = requests.get(f"https://gitlab.lamoda.tech/api/v4/projects/{project_id}/merge_requests/{mr_iid}/approvals", 
-                       headers={"PRIVATE-TOKEN": GITLAB_TOKEN}, verify=False)
+        r = requests.get(
+            f"https://gitlab.lamoda.tech/api/v4/projects/{project_id}/merge_requests/{mr_iid}/approvals",
+            headers={"PRIVATE-TOKEN": GITLAB_TOKEN},
+            timeout=REQUEST_TIMEOUT,
+        )
         r.raise_for_status()
         time.sleep(1)
         approvals = len(r.json().get("approved_by", []))
@@ -74,8 +107,11 @@ def get_approval_count(mr_iid, project_id):
 def get_mr_details(mr_iid, project_id):
     try:
         logger.info(f"Получение деталей MR !{mr_iid}")
-        r = requests.get(f"https://gitlab.lamoda.tech/api/v4/projects/{project_id}/merge_requests/{mr_iid}", 
-                       headers={"PRIVATE-TOKEN": GITLAB_TOKEN}, verify=False)
+        r = requests.get(
+            f"https://gitlab.lamoda.tech/api/v4/projects/{project_id}/merge_requests/{mr_iid}",
+            headers={"PRIVATE-TOKEN": GITLAB_TOKEN},
+            timeout=REQUEST_TIMEOUT,
+        )
         r.raise_for_status()
         time.sleep(1)
         return r.json()
@@ -86,8 +122,11 @@ def get_mr_details(mr_iid, project_id):
 def get_mr_comments(mr_iid, project_id):
     try:
         logger.info(f"Получение комментариев для MR !{mr_iid}")
-        r = requests.get(f"https://gitlab.lamoda.tech/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes?sort=desc", 
-                       headers={"PRIVATE-TOKEN": GITLAB_TOKEN}, verify=False)
+        r = requests.get(
+            f"https://gitlab.lamoda.tech/api/v4/projects/{project_id}/merge_requests/{mr_iid}/notes?sort=desc",
+            headers={"PRIVATE-TOKEN": GITLAB_TOKEN},
+            timeout=REQUEST_TIMEOUT,
+        )
         r.raise_for_status()
         time.sleep(1)
         return r.json()
@@ -95,11 +134,11 @@ def get_mr_comments(mr_iid, project_id):
         logger.error(f"Ошибка при получении комментариев MR !{mr_iid}: {e}")
         raise
 
-def extract_jira_key_from_text(text):
+def extract_jira_key_from_text(text: str) -> Optional[str]:
     try:
         match = re.search(r'\b[A-Z]+-\d+\b', text)
         jira_key = match.group(0) if match else None
-        logger.info(f"Найден ключ Jira: {jira_key} в тексте: {text[:100]}...")
+        logger.info(f"Найден ключ Jira: {jira_key}")
         return jira_key
     except Exception as e:
         logger.error(f"Ошибка при поиске ключа Jira в тексте: {e}")
@@ -158,6 +197,7 @@ def mark_reminder_sent(mr_key):
 
 
 def main():
+    chat_id = validate_env()
     monitored, reported_mrs, shutdown_requested = {}, set(), False
     tracked_comments = {}
     mr_project_ids = {}  # Словарь для хранения project_id по MR iid
@@ -168,7 +208,7 @@ def main():
             shutdown_requested = True
             logger.info("Получен сигнал завершения, начинаю graceful shutdown")
             try:
-                send_pacha_message("🛑 Мониторинг MR прекращен")
+                send_pacha_message("🛑 Мониторинг MR прекращен", chat_id)
                 logger.info("Отправлено уведомление о прекращении мониторинга")
             except Exception as e:
                 logger.error(f"Ошибка при отправке уведомления о завершении: {e}")
@@ -178,12 +218,12 @@ def main():
     signal.signal(signal.SIGTERM, signal_handler)
 
     logger.info("Запуск мониторинга MR...")
-    send_pacha_message("Запуск мониторинга MR...")
+    send_pacha_message("Запуск мониторинга MR...", chat_id)
 
     while True:
         try:
             logger.info("Начало новой итерации проверки")
-            open_mrs = get_open_mrs()
+            open_mrs = get_open_mrs(chat_id)
             new_mrs = []
 
             for mr in open_mrs:
@@ -205,7 +245,7 @@ def main():
                 new_mrs_text = "\n".join([f"🆕 {mr}" for mr in new_mrs])
                 message = f"Новые MR добавлены в мониторинг:\n{new_mrs_text}"
                 logger.info(f"Отправка уведомления о {len(new_mrs)} новых MR")
-                send_pacha_message(message)
+                send_pacha_message(message, chat_id)
 
             logger.info(f"Проверка {len(monitored)} MR на аппрувы и комментарии")
             for mr_key in list(monitored.keys()):
@@ -248,7 +288,7 @@ def main():
                                 body = comment["body"][:200] + "..." if len(comment["body"]) > 200 else comment["body"]
                                 message = f"💬 Новый комментарий в MR \"{title}\" от {author}:\n{body}"
                                 logger.info(f"Отправка уведомления о новом комментарии в MR !{iid}")
-                                send_pacha_message(message)
+                                send_pacha_message(message, chat_id)
                         
                         tracked_comments[mr_key] = current_comment_ids
                         logger.info(f"Обновлен список отслеживаемых комментариев для MR !{iid}: {len(current_comment_ids)}")
@@ -272,7 +312,7 @@ def main():
                     mr_link = f"\nMR: {mr_details.get('web_url', '')}" if mr_details.get('web_url') else ""
                     message = f"🎉 MR \"{title}\" получил {approvals} аппрува!{jira_link}{mr_link}"
                     logger.info(f"Отправка уведомления о достижении целевых аппрувов: {message}")
-                    send_pacha_message(message)
+                    send_pacha_message(message, chat_id)
                     reported_mrs.add(mr_key)
 
                 # Проверка на напоминание о старом MR
@@ -303,6 +343,7 @@ def main():
                     work_hours_elapsed = 0
                     current_time = created_time
                     
+                    now = datetime.now()
                     while current_time < now:
                         if not is_weekend(current_time):
                             work_hours_elapsed += 1
@@ -313,7 +354,7 @@ def main():
                     
                     message = f"⏰ MR \"{title}\" ждет уже {work_hours_elapsed} рабочих часов! Можно сделать напоминание.{jira_link}{mr_link}"
                     logger.info(f"Отправка напоминания о старом MR: {message}")
-                    send_pacha_message(message)
+                    send_pacha_message(message, chat_id)
                     mark_reminder_sent(mr_key)
 
             logger.info(f"Итерация завершена, следующая проверка через {CHECK_INTERVAL} секунд")
@@ -321,7 +362,7 @@ def main():
         except Exception as e:
             logger.error(f"Ошибка в основной петле мониторинга: {e}", exc_info=True)
             try:
-                send_pacha_message(f"Ошибка: {e}")
+                send_pacha_message(f"Ошибка: {e}", chat_id)
             except Exception as notify_error:
                 logger.error(f"Не удалось отправить уведомление об ошибке: {notify_error}")
 


### PR DESCRIPTION
### Motivation
- Improve security and reliability of the two monitoring scripts by removing unsafe network patterns and making startup configuration explicit. 
- Prevent long-hanging requests and accidental leaking of sensitive data into logs.

### Description
- Replaced unsafe `verify=False` usage with default TLS verification and added a configurable `REQUEST_TIMEOUT` for all outbound HTTP calls in `merge.py` and `jira_done_checker.py` to avoid hanging network calls. 
- Added startup environment validation via `validate_env()` that checks required vars and strictly parses `PACHA_CHAT_ID` as an `int`, failing fast with a clear error if misconfigured. 
- Centralized Pachca notification call to `send_pacha_message(..., chat_id)` and reduced sensitive logging by stopping logging of full outgoing message contents and long text snippets (Jira key logging kept minimal). 
- Fixed a runtime bug in `merge.py` where `now` could be used before initialization (now explicitly set before computing elapsed work hours) and added `CHECK_INTERVAL`-driven delay in `jira_done_checker.py` main loop to avoid tight polling.

### Testing
- Compiled both scripts to ensure syntax validity with `python -m py_compile merge.py jira_done_checker.py` which completed successfully. 
- Ran `python -m compileall merge.py jira_done_checker.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb884e1bc8332a4ab5a123f0d68fd)