### PR TITLE
fix: исправление 4 багов в мониторинге MR и проверке Jira

### DIFF
--- a/jira_done_checker.py
+++ b/jira_done_checker.py
@@ -11,6 +11,7 @@ JIRA_TOKEN = os.getenv("JIRA_TOKEN")
 PACCHA_BOT_TOKEN = os.getenv("PACCHA_BOT_TOKEN")
 PACHA_CHAT_ID = int(os.getenv("PACHA_CHAT_ID"))
 JIRA_URL = "https://jira.lamoda.ru"
+CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", "30"))
 
 def send_pacha_message(text):
     try:
@@ -157,7 +158,7 @@ def main():
                 logger.info(f"Проверка MR !{iid}: {title}")
                 
                 # Извлекаем ключ Jira из заголовка и описания
-                jira_key = extract_jira_key_from_text(title + " " + mr.get("description", ""))
+                jira_key = extract_jira_key_from_text(title + " " + (mr.get("description", "") or ""))
                 
                 if not jira_key:
                     logger.info(f"В MR !{iid} не найден ключ Jira, пропускаем")
@@ -223,6 +224,9 @@ def main():
                 send_pacha_message(f"❌ Ошибка в проверке задач Jira: {e}")
             except Exception as notify_error:
                 logger.error(f"Не удалось отправить уведомление об ошибке: {notify_error}")
+
+        logger.info(f"Итерация завершена, следующая проверка через {CHECK_INTERVAL} секунд")
+        time.sleep(CHECK_INTERVAL)
 
 if __name__ == "__main__":
     main()

--- a/merge.py
+++ b/merge.py
@@ -197,7 +197,13 @@ def main():
                 
                 if mr_key not in monitored:
                     monitored[mr_key] = 0
-                    tracked_comments[mr_key] = set()
+                    # Инициализируем отслеживаемые комментарии текущими, чтобы не слать уведомления о старых комментариях
+                    try:
+                        existing_comments = get_mr_comments(iid, project_id)
+                        tracked_comments[mr_key] = {str(c["id"]) for c in existing_comments}
+                    except Exception as e:
+                        logger.error(f"Ошибка при инициализации комментариев для MR !{iid}: {e}")
+                        tracked_comments[mr_key] = set()
                     new_mrs.append(f"!{iid}: {title}")
                     logger.info(f"Новый MR !{iid} ({title}) добавлен в мониторинг, project_id: {project_id}")
 
@@ -302,6 +308,7 @@ def main():
                     # Считаем только рабочие часы (исключая выходные)
                     work_hours_elapsed = 0
                     current_time = created_time
+                    now = datetime.now()
                     
                     while current_time < now:
                         if not is_weekend(current_time):


### PR DESCRIPTION
## Summary

Fixes four bugs across `merge.py` and `jira_done_checker.py`:

1. **`NameError` crash in reminder block** (`merge.py`): The variable `now` was used in the old-MR reminder's working-hours loop but never defined in that scope. Added `now = datetime.now()` before the loop.

2. **`TypeError` on `None` description** (`jira_done_checker.py`): `mr.get("description", "")` returns `None` when the key exists but has a null value (common in GitLab API responses), causing a crash on string concatenation. Wrapped with `or ""` to match the pattern already used in `merge.py`.

3. **Missing sleep between iterations** (`jira_done_checker.py`): The `while True` loop had no pause, causing infinite rapid API calls. Added `CHECK_INTERVAL` (env-configurable, default 30s) and `time.sleep()` to match `merge.py` behavior.

4. **All existing comments reported as new on startup** (`merge.py`): When a new MR was first discovered, `tracked_comments` was initialized to an empty set, so every existing comment triggered a notification. Now fetches current comments on first discovery and seeds the tracking set with their IDs.

## Review & Testing Checklist for Human

- [ ] Verify the `now = datetime.now()` placement at line 311 is correct — it should be defined before the `while current_time < now:` loop and after `created_time` is parsed
- [ ] Confirm that fetching existing comments during MR discovery (fix #4) doesn't cause excessive API load if many MRs are added simultaneously — each new MR now triggers one extra `get_mr_comments` call
- [ ] Test a restart of the monitor and confirm old comments are **not** re-sent as notifications
- [ ] Verify `CHECK_INTERVAL=30` default is appropriate for the Jira checker's use case (it may need a different cadence than the MR monitor)

### Notes

- The working-hours calculation in the reminder block (lines ~308–316) is duplicated from `should_send_reminder()` — this is a pre-existing issue, not introduced here.
- No automated tests exist in this repo; all fixes were verified via syntax check (`py_compile`) only.

Link to Devin session: https://app.devin.ai/sessions/25d5fe165e27450e8f3439d5e65fb571
Requested by: @Arist-create